### PR TITLE
設問ごとの入力内容クリア機能を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,10 @@
                                 </div>
                             </div>
                             
-                            <button type="button" class="insert-headings-btn">見出しを転記</button>
+                            <div class="section-buttons">
+                                <button type="button" class="insert-headings-btn">見出しを転記</button>
+                                <button type="button" class="clear-section-btn" data-section="A">クリア</button>
+                            </div>
                         </div>
                     </div>
 
@@ -133,7 +136,10 @@
                                 </div>
                             </div>
                             
-                            <button type="button" class="insert-headings-btn">見出しを転記</button>
+                            <div class="section-buttons">
+                                <button type="button" class="insert-headings-btn">見出しを転記</button>
+                                <button type="button" class="clear-section-btn" data-section="B">クリア</button>
+                            </div>
                         </div>
                     </div>
 
@@ -190,7 +196,10 @@
                                 </div>
                             </div>
                             
-                            <button type="button" class="insert-headings-btn">見出しを転記</button>
+                            <div class="section-buttons">
+                                <button type="button" class="insert-headings-btn">見出しを転記</button>
+                                <button type="button" class="clear-section-btn" data-section="C">クリア</button>
+                            </div>
                         </div>
                     </div>
 

--- a/script.js
+++ b/script.js
@@ -574,6 +574,75 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 
+    // クリアボタンのイベントリスナーを追加
+    document.querySelectorAll('.clear-section-btn').forEach(button => {
+        button.addEventListener('click', function() {
+            const sectionLetter = this.getAttribute('data-section');
+            clearSection(sectionLetter);
+        });
+    });
+
+    // セクションクリア機能
+    function clearSection(sectionLetter) {
+        if (!confirm(`設問${sectionLetter}の入力内容をすべてクリアしますか？`)) {
+            return;
+        }
+
+        const sectionMap = {
+            'A': 'questionA',
+            'B': 'questionB', 
+            'C': 'questionC'
+        };
+        
+        const textareaId = sectionMap[sectionLetter];
+        const section = document.querySelector(`#${textareaId}`).closest('.question-section');
+        
+        // 見出し入力欄をクリア
+        const headingInputs = section.querySelectorAll('.main-heading, .sub-heading, .subtopic');
+        headingInputs.forEach(input => {
+            input.value = '';
+        });
+        
+        // テキストエリアをクリア
+        const textarea = section.querySelector('.answer-textarea');
+        textarea.value = '';
+        
+        // 文字数カウンターを更新
+        updateCharCount(textarea);
+        
+        // ローカルストレージからデータを削除
+        clearSectionFromStorage(sectionLetter);
+        
+        console.log(`設問${sectionLetter}の入力内容をクリアしました`);
+    }
+
+    // ローカルストレージから特定セクションのデータを削除
+    function clearSectionFromStorage(sectionLetter) {
+        const sectionMap = {
+            'A': 'questionA',
+            'B': 'questionB',
+            'C': 'questionC'
+        };
+        
+        const textareaId = sectionMap[sectionLetter];
+        
+        // テキストエリアのデータを削除
+        localStorage.removeItem(textareaId);
+        
+        // 見出しデータを削除
+        const headingKeys = [
+            `${sectionLetter}_main_heading`,
+            `${sectionLetter}_sub_heading_1`, `${sectionLetter}_sub_heading_2`, `${sectionLetter}_sub_heading_3`,
+            `${sectionLetter}_subtopic_1_1`, `${sectionLetter}_subtopic_1_2`,
+            `${sectionLetter}_subtopic_2_1`, `${sectionLetter}_subtopic_2_2`,
+            `${sectionLetter}_subtopic_3_1`, `${sectionLetter}_subtopic_3_2`
+        ];
+        
+        headingKeys.forEach(key => {
+            localStorage.removeItem(key);
+        });
+    }
+
     function exportForAIGrading() {
         const data = collectData();
         let aiPromptText = `以下は、プロジェクトマネージャ試験の午後Ⅱ（論述式試験）の回答です。以下の採点基準に従って評価し、改善点を具体的に指摘してください：

--- a/style.css
+++ b/style.css
@@ -266,8 +266,13 @@ header h1 {
     width: 100%;
 }
 
-.insert-headings-btn {
+.section-buttons {
     margin-top: 8px;
+    display: flex;
+    gap: 8px;
+}
+
+.insert-headings-btn {
     padding: 6px 12px;
     background: linear-gradient(135deg, #9b59b6, #8e44ad);
     color: white;
@@ -280,6 +285,19 @@ header h1 {
     box-shadow: 0 3px 10px rgba(155, 89, 182, 0.3);
 }
 
+.clear-section-btn {
+    padding: 6px 12px;
+    background: linear-gradient(135deg, #e74c3c, #c0392b);
+    color: white;
+    border: none;
+    border-radius: 16px;
+    font-size: 0.8rem;
+    font-weight: bold;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 3px 10px rgba(231, 76, 60, 0.3);
+}
+
 .insert-headings-btn:hover {
     background: linear-gradient(135deg, #8e44ad, #732d91);
     transform: translateY(-2px);
@@ -289,6 +307,17 @@ header h1 {
 .insert-headings-btn:active {
     transform: translateY(0);
     box-shadow: 0 2px 8px rgba(155, 89, 182, 0.3);
+}
+
+.clear-section-btn:hover {
+    background: linear-gradient(135deg, #c0392b, #a93226);
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px rgba(231, 76, 60, 0.4);
+}
+
+.clear-section-btn:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 8px rgba(231, 76, 60, 0.3);
 }
 
 .main-heading:focus,


### PR DESCRIPTION
## Summary
- 各設問セクション（設問ア、イ、ウ）に「クリア」ボタンを追加
- 見出し入力欄とテキストエリアの内容を一括でクリアする機能を実装
- ローカルストレージからも対応するデータを削除して完全リセット
- 確認ダイアログで誤操作を防止

## Test plan
- [x] 各設問のクリアボタンが正常に表示されることを確認
- [x] クリアボタンをクリックすると確認ダイアログが表示されることを確認
- [x] 確認後に見出し入力欄とテキストエリアがクリアされることを確認
- [x] ローカルストレージからデータが削除されることを確認
- [x] キャンセル時は何も変更されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)