### PR TITLE
見出し転記時のサブトピックインデントを削除

### DIFF
--- a/script.js
+++ b/script.js
@@ -535,7 +535,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 
                 // サブトピックがある場合は追加
                 subtopics.forEach((subtopic, subIndex) => {
-                    headingsText += '  (' + (subIndex + 1) + ') ' + subtopic + '\n';
+                    headingsText += '(' + (subIndex + 1) + ') ' + subtopic + '\n';
                 });
             }
         });


### PR DESCRIPTION
## Summary
- 見出し転記時のサブトピック (1), (2) の前のスペースインデントを削除
- より見やすく整理された見出し形式に改善

## Changes
- `insertHeadings`関数でサブトピックの行頭スペースを除去
- 従来: `  (1) サブトピック` → 新: `(1) サブトピック`

## Test plan
- [ ] 見出し転記機能が正常に動作することを確認
- [ ] サブトピックにインデントが入らないことを確認
- [ ] 見出し構造が適切に保持されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)